### PR TITLE
Add DOS game loader, runtime abstractions, and CLI launch flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ChildhoodGame (.NET)
 
-This repository is now a C#/.NET solution for running a DOS-game host and game-session orchestration logic.
+This repository is a C#/.NET solution that validates and launches DOS games through a configurable runtime.
 
 ## Projects
 
-- `src/ChildhoodGame.Runner`: Console/desktop host entry point that starts a game session.
-- `src/ChildhoodGame.Core`: Domain orchestration and win-condition evaluation logic.
+- `src/ChildhoodGame.Runner`: Console host with CLI options for validation and runtime launch.
+- `src/ChildhoodGame.Core`: Loader/runtime abstractions and DOS emulator strategy integration.
 
 ## SDK and framework version
 
@@ -13,36 +13,41 @@ This repository is now a C#/.NET solution for running a DOS-game host and game-s
 - Language version: **C# 10** via explicit `<LangVersion>10.0</LangVersion>`.
 - `global.json` pins SDK version **10.0.103** with `rollForward: latestFeature`.
 
-> Note: `.NET 14` is not a current released target framework. The latest stable .NET target listed by Microsoft Learn is `.NET 10` (`net10.0`), so this repository is upgraded to `.NET 10` while keeping the language level pinned to `C# 10`.
-
-## Prerequisites
-
-1. Install the .NET 10 SDK (10.0.103 or newer compatible 10.0 feature band).
-2. Verify installation:
+## CLI usage
 
 ```bash
-dotnet --info
+dotnet run --project src/ChildhoodGame.Runner/ChildhoodGame.Runner.csproj -- \
+  --game-path /path/to/game \
+  --run \
+  --save-state /path/to/save.sav \
+  --load-state /path/to/load.sav
 ```
 
-## Restore and build
+### Supported options
 
-From repo root:
+- `--game-path` (required): root folder containing game assets.
+- `--run` (optional): starts the runtime after validation; if omitted, validation-only mode is used.
+- `--save-state` (optional): path where save-state should be written by emulator wrapper.
+- `--load-state` (optional): path for a save-state to load at startup.
 
-```bash
-dotnet restore ChildhoodGame.sln
-dotnet build ChildhoodGame.sln -c Release
+## Game folder requirements
+
+The loader validates:
+
+- `DOSBOX.CONF`
+- `game.config.json`
+- executable specified by `requiredExecutable` (defaults to `GAME.EXE`)
+
+`game.config.json` example:
+
+```json
+{
+  "emulatorType": "wrapper",
+  "emulatorExecutable": "dosbox",
+  "emulatorArguments": "-conf \"{config}\" -c \"mount c .\" -c \"c:\" -c \"{exe}\"",
+  "startupInput": ["ENTER"],
+  "requiredExecutable": "GAME.EXE"
+}
 ```
 
-## Run
-
-Use the runner project:
-
-```bash
-dotnet run --project src/ChildhoodGame.Runner/ChildhoodGame.Runner.csproj
-```
-
-Expected output includes launch text and whether the win condition was met.
-
-## No Node.js runtime required
-
-Node/Angular build files were removed from the root workflow, and all executable entry points are now in C# (`Program.cs` under `ChildhoodGame.Runner`).
+Use `emulatorType: "embedded"` for embedded-core mode.

--- a/src/ChildhoodGame.Core/DosGameLoader.cs
+++ b/src/ChildhoodGame.Core/DosGameLoader.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+
+namespace ChildhoodGame.Core;
+
+public sealed class DosGameLoader : IGameLoader
+{
+    private static readonly string[] RequiredAssets =
+    [
+        "DOSBOX.CONF"
+    ];
+
+    public GameLoadResult Load(GameLaunchOptions options)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.GamePath))
+        {
+            errors.Add("A game path is required.");
+            return new GameLoadResult(false, null, errors);
+        }
+
+        var gameRootPath = Path.GetFullPath(options.GamePath);
+        if (!Directory.Exists(gameRootPath))
+        {
+            errors.Add($"Game path does not exist: {gameRootPath}");
+            return new GameLoadResult(false, null, errors);
+        }
+
+        foreach (var asset in RequiredAssets)
+        {
+            var assetPath = Path.Combine(gameRootPath, asset);
+            if (!File.Exists(assetPath))
+            {
+                errors.Add($"Missing required DOS asset: {assetPath}");
+            }
+        }
+
+        var configPath = Path.Combine(gameRootPath, DosRuntimeConfig.ConfigFileName);
+        DosRuntimeConfig? config = null;
+
+        if (!File.Exists(configPath))
+        {
+            errors.Add($"Missing runtime config file: {configPath}");
+        }
+        else
+        {
+            try
+            {
+                var raw = File.ReadAllText(configPath);
+                config = JsonSerializer.Deserialize<DosRuntimeConfig>(raw, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                if (config is null)
+                {
+                    errors.Add($"Runtime config could not be parsed: {configPath}");
+                }
+                else if (string.IsNullOrWhiteSpace(config.EmulatorType))
+                {
+                    errors.Add("Runtime config must include emulatorType.");
+                }
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Failed to parse runtime config '{configPath}': {ex.Message}");
+            }
+        }
+
+        if (config is not null && config.EmulatorType.Equals("wrapper", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(config.EmulatorExecutable))
+            {
+                errors.Add("Runtime config must include emulatorExecutable when emulatorType is 'wrapper'.");
+            }
+        }
+
+        var requiredExecutable = config?.RequiredExecutable ?? "GAME.EXE";
+        var executablePath = Path.Combine(gameRootPath, requiredExecutable);
+        if (!File.Exists(executablePath))
+        {
+            errors.Add($"Missing required executable: {executablePath}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.LoadStatePath))
+        {
+            var loadStatePath = Path.GetFullPath(options.LoadStatePath);
+            if (!File.Exists(loadStatePath))
+            {
+                errors.Add($"Load-state file does not exist: {loadStatePath}");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.SaveStatePath))
+        {
+            var saveStatePath = Path.GetFullPath(options.SaveStatePath);
+            var parentDirectory = Path.GetDirectoryName(saveStatePath);
+            if (string.IsNullOrWhiteSpace(parentDirectory) || !Directory.Exists(parentDirectory))
+            {
+                errors.Add($"Save-state directory does not exist: {parentDirectory}");
+            }
+        }
+
+        if (errors.Count > 0 || config is null)
+        {
+            return new GameLoadResult(false, null, errors);
+        }
+
+        var package = new GamePackage(
+            GameRootPath: gameRootPath,
+            GameExecutablePath: executablePath,
+            DosConfigPath: Path.Combine(gameRootPath, "DOSBOX.CONF"),
+            RuntimeConfig: config,
+            SaveStatePath: options.SaveStatePath is null ? null : Path.GetFullPath(options.SaveStatePath),
+            LoadStatePath: options.LoadStatePath is null ? null : Path.GetFullPath(options.LoadStatePath));
+
+        return new GameLoadResult(true, package, Array.Empty<string>());
+    }
+}

--- a/src/ChildhoodGame.Core/DosGameRuntime.cs
+++ b/src/ChildhoodGame.Core/DosGameRuntime.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics;
+
+namespace ChildhoodGame.Core;
+
+public interface IDosEmulatorStrategy : IAsyncDisposable
+{
+    bool IsRunning { get; }
+
+    Task StartAsync(GamePackage gamePackage, CancellationToken cancellationToken = default);
+
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    Task SendInputAsync(string inputCommand, CancellationToken cancellationToken = default);
+}
+
+public sealed class DosGameRuntime : IGameRuntime
+{
+    private readonly Func<DosRuntimeConfig, IDosEmulatorStrategy> strategyFactory;
+    private IDosEmulatorStrategy? strategy;
+
+    public DosGameRuntime(Func<DosRuntimeConfig, IDosEmulatorStrategy>? strategyFactory = null)
+    {
+        this.strategyFactory = strategyFactory ?? CreateDefaultStrategy;
+    }
+
+    public bool IsRunning => strategy?.IsRunning == true;
+
+    public async Task StartAsync(GamePackage gamePackage, CancellationToken cancellationToken = default)
+    {
+        strategy = strategyFactory(gamePackage.RuntimeConfig);
+        await strategy.StartAsync(gamePackage, cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (strategy is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return strategy.StopAsync(cancellationToken);
+    }
+
+    public Task SendInputAsync(string inputCommand, CancellationToken cancellationToken = default)
+    {
+        if (strategy is null)
+        {
+            throw new InvalidOperationException("Runtime has not been started.");
+        }
+
+        return strategy.SendInputAsync(inputCommand, cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (strategy is not null)
+        {
+            await strategy.DisposeAsync();
+        }
+    }
+
+    private static IDosEmulatorStrategy CreateDefaultStrategy(DosRuntimeConfig config) =>
+        config.EmulatorType.Equals("embedded", StringComparison.OrdinalIgnoreCase)
+            ? new EmbeddedCoreDosEmulatorStrategy()
+            : new WrapperProcessDosEmulatorStrategy(config.EmulatorExecutable!, config.EmulatorArguments);
+}
+
+public sealed class WrapperProcessDosEmulatorStrategy(string emulatorExecutable, string? emulatorArguments) : IDosEmulatorStrategy
+{
+    private readonly string emulatorExecutable = emulatorExecutable;
+    private readonly string? emulatorArguments = emulatorArguments;
+    private Process? process;
+
+    public bool IsRunning => process is { HasExited: false };
+
+    public Task StartAsync(GamePackage gamePackage, CancellationToken cancellationToken = default)
+    {
+        if (IsRunning)
+        {
+            return Task.CompletedTask;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = emulatorExecutable,
+            Arguments = BuildArguments(gamePackage),
+            WorkingDirectory = gamePackage.GameRootPath,
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            CreateNoWindow = true
+        };
+
+        process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start emulator process: {emulatorExecutable}");
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (process is null)
+        {
+            return;
+        }
+
+        if (!process.HasExited)
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync(cancellationToken);
+        }
+    }
+
+    public async Task SendInputAsync(string inputCommand, CancellationToken cancellationToken = default)
+    {
+        if (process is null || process.HasExited)
+        {
+            throw new InvalidOperationException("Emulator process is not running.");
+        }
+
+        await process.StandardInput.WriteLineAsync(inputCommand.AsMemory(), cancellationToken);
+        await process.StandardInput.FlushAsync(cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync();
+        process?.Dispose();
+    }
+
+    private string BuildArguments(GamePackage gamePackage)
+    {
+        var args = emulatorArguments ?? string.Empty;
+        args = args.Replace("{config}", gamePackage.DosConfigPath, StringComparison.OrdinalIgnoreCase);
+        args = args.Replace("{exe}", gamePackage.GameExecutablePath, StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(gamePackage.LoadStatePath))
+        {
+            args += $" --loadstate \"{gamePackage.LoadStatePath}\"";
+        }
+
+        if (!string.IsNullOrWhiteSpace(gamePackage.SaveStatePath))
+        {
+            args += $" --savestate \"{gamePackage.SaveStatePath}\"";
+        }
+
+        return args.Trim();
+    }
+}
+
+public sealed class EmbeddedCoreDosEmulatorStrategy : IDosEmulatorStrategy
+{
+    public bool IsRunning { get; private set; }
+
+    public Task StartAsync(GamePackage gamePackage, CancellationToken cancellationToken = default)
+    {
+        IsRunning = true;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        IsRunning = false;
+        return Task.CompletedTask;
+    }
+
+    public Task SendInputAsync(string inputCommand, CancellationToken cancellationToken = default)
+    {
+        if (!IsRunning)
+        {
+            throw new InvalidOperationException("Embedded emulator core is not running.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        IsRunning = false;
+        return ValueTask.CompletedTask;
+    }
+}
+
+public sealed class RuntimeInputController(IGameRuntime runtime) : IInputController
+{
+    public Task SendCommandAsync(string command, CancellationToken cancellationToken = default) =>
+        runtime.SendInputAsync(command, cancellationToken);
+}

--- a/src/ChildhoodGame.Core/GameHostingAbstractions.cs
+++ b/src/ChildhoodGame.Core/GameHostingAbstractions.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+
+namespace ChildhoodGame.Core;
+
+public interface IGameLoader
+{
+    GameLoadResult Load(GameLaunchOptions options);
+}
+
+public interface IGameRuntime : IAsyncDisposable
+{
+    bool IsRunning { get; }
+
+    Task StartAsync(GamePackage gamePackage, CancellationToken cancellationToken = default);
+
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    Task SendInputAsync(string inputCommand, CancellationToken cancellationToken = default);
+}
+
+public interface IInputController
+{
+    Task SendCommandAsync(string command, CancellationToken cancellationToken = default);
+}
+
+public sealed record GameLaunchOptions(
+    string GamePath,
+    bool Run,
+    string? SaveStatePath = null,
+    string? LoadStatePath = null);
+
+public sealed record GameLoadResult(
+    bool IsValid,
+    GamePackage? GamePackage,
+    IReadOnlyList<string> Errors);
+
+public sealed record GamePackage(
+    string GameRootPath,
+    string GameExecutablePath,
+    string DosConfigPath,
+    DosRuntimeConfig RuntimeConfig,
+    string? SaveStatePath,
+    string? LoadStatePath);
+
+public sealed record DosRuntimeConfig(
+    [property: JsonPropertyName("emulatorType")] string EmulatorType,
+    [property: JsonPropertyName("emulatorExecutable")] string? EmulatorExecutable,
+    [property: JsonPropertyName("emulatorArguments")] string? EmulatorArguments,
+    [property: JsonPropertyName("startupInput")] string[]? StartupInput,
+    [property: JsonPropertyName("requiredExecutable")] string? RequiredExecutable)
+{
+    public const string ConfigFileName = "game.config.json";
+}

--- a/src/ChildhoodGame.Runner/Program.cs
+++ b/src/ChildhoodGame.Runner/Program.cs
@@ -1,14 +1,169 @@
 using ChildhoodGame.Core;
 
-var orchestrator = new GameOrchestrator();
+var logger = new ConsoleGameLogger();
 
-var request = new GameSessionRequest(
-    DosGameTitle: "Commander Keen",
-    MaxTurns: 5,
-    TurnsRequiredToWin: 3);
+var parsed = CliOptions.Parse(args);
+if (!parsed.IsValid)
+{
+    foreach (var error in parsed.Errors)
+    {
+        logger.Error(error);
+    }
 
-var result = orchestrator.Run(request);
+    CliOptions.PrintUsage();
+    return 1;
+}
 
-Console.WriteLine($"Launching DOS host for: {request.DosGameTitle}");
-Console.WriteLine(result.Summary);
-Console.WriteLine(result.IsWin ? "Win condition met." : "Win condition not met.");
+var launchOptions = parsed.Options!;
+var loader = new DosGameLoader();
+var loadResult = loader.Load(launchOptions);
+
+if (!loadResult.IsValid || loadResult.GamePackage is null)
+{
+    logger.Error("Game launch validation failed.");
+    foreach (var error in loadResult.Errors)
+    {
+        logger.Error(error);
+    }
+
+    return 2;
+}
+
+logger.Info($"Validated game package at '{loadResult.GamePackage.GameRootPath}'.");
+
+if (!launchOptions.Run)
+{
+    logger.Info("Validation complete. Use --run to launch the game runtime.");
+    return 0;
+}
+
+try
+{
+    await using var runtime = new DosGameRuntime();
+    var inputController = new RuntimeInputController(runtime);
+
+    logger.Info("Starting DOS runtime.");
+    await runtime.StartAsync(loadResult.GamePackage);
+
+    var startupInput = loadResult.GamePackage.RuntimeConfig.StartupInput;
+    if (startupInput is { Length: > 0 })
+    {
+        foreach (var command in startupInput)
+        {
+            await inputController.SendCommandAsync(command);
+            logger.Info($"Startup input sent: {command}");
+        }
+    }
+
+    logger.Info("Runtime started successfully. Press ENTER to stop.");
+    Console.ReadLine();
+
+    await runtime.StopAsync();
+    logger.Info("Runtime stopped cleanly.");
+    return 0;
+}
+catch (Exception ex)
+{
+    logger.Error($"Runtime crash detected: {ex.Message}");
+    logger.Error(ex.ToString());
+    return 3;
+}
+
+internal sealed class CliOptions
+{
+    public GameLaunchOptions? Options { get; init; }
+
+    public bool IsValid => Errors.Count == 0 && Options is not null;
+
+    public List<string> Errors { get; } = new();
+
+    public static CliOptions Parse(string[] args)
+    {
+        var result = new CliOptions();
+
+        string? gamePath = null;
+        bool run = false;
+        string? saveState = null;
+        string? loadState = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--game-path":
+                    if (!TryReadValue(args, ref i, out gamePath))
+                    {
+                        result.Errors.Add("--game-path requires a value.");
+                    }
+
+                    break;
+                case "--run":
+                    run = true;
+                    break;
+                case "--save-state":
+                    if (!TryReadValue(args, ref i, out saveState))
+                    {
+                        result.Errors.Add("--save-state requires a value.");
+                    }
+
+                    break;
+                case "--load-state":
+                    if (!TryReadValue(args, ref i, out loadState))
+                    {
+                        result.Errors.Add("--load-state requires a value.");
+                    }
+
+                    break;
+                case "--help":
+                case "-h":
+                    PrintUsage();
+                    Environment.Exit(0);
+                    break;
+                default:
+                    result.Errors.Add($"Unknown argument: {args[i]}");
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(gamePath))
+        {
+            result.Errors.Add("--game-path is required.");
+        }
+
+        if (result.Errors.Count == 0)
+        {
+            result.Options = new GameLaunchOptions(gamePath!, run, saveState, loadState);
+        }
+
+        return result;
+    }
+
+    public static void PrintUsage()
+    {
+        Console.WriteLine("Usage: ChildhoodGame.Runner --game-path <path> [--run] [--save-state <path>] [--load-state <path>]");
+    }
+
+    private static bool TryReadValue(string[] args, ref int index, out string? value)
+    {
+        if (index + 1 >= args.Length)
+        {
+            value = null;
+            return false;
+        }
+
+        value = args[++index];
+        return true;
+    }
+}
+
+internal sealed class ConsoleGameLogger
+{
+    public void Info(string message) => Write("INFO", message);
+
+    public void Error(string message) => Write("ERROR", message);
+
+    private static void Write(string level, string message)
+    {
+        Console.Error.WriteLine($"{DateTimeOffset.UtcNow:O} [{level}] {message}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide clear hosting abstractions for loading and running DOS games by introducing `IGameLoader`, `IGameRuntime`, and `IInputController` to separate validation, runtime control, and input concerns.
- Ensure robust validation of game folders and runtime configuration so missing DOS assets, configs, or executables are detected before launch.
- Support multiple emulator integration approaches (wrapper process or embedded core) and expose a simple CLI so games can be validated and launched from the console with meaningful logs on failure.

### Description
- Added core abstractions and data records in `src/ChildhoodGame.Core/GameHostingAbstractions.cs` including `IGameLoader`, `IGameRuntime`, `IInputController`, `GameLaunchOptions`, `GameLoadResult`, `GamePackage`, and `DosRuntimeConfig` with `game.config.json` conventions. 
- Implemented `DosGameLoader` in `src/ChildhoodGame.Core/DosGameLoader.cs` which validates `--game-path` existence, required assets (`DOSBOX.CONF`), runtime config parsing and fields, required executable presence, and optional `--save-state`/`--load-state` paths. 
- Implemented `DosGameRuntime` and emulator strategies in `src/ChildhoodGame.Core/DosGameRuntime.cs`, including `WrapperProcessDosEmulatorStrategy` to spawn and control an external emulator process and `EmbeddedCoreDosEmulatorStrategy` as a scaffolded in-process mode, plus `RuntimeInputController` to forward input to the runtime. 
- Updated `src/ChildhoodGame.Runner/Program.cs` to add CLI parsing for `--game-path`, `--run`, `--save-state`, and `--load-state`, to validate with the loader, to start/stop the runtime, to apply `startupInput` commands, and to add structured logging and exit codes for validation failures and runtime crashes. 
- Updated `README.md` with CLI usage, supported options, game folder requirements, and a `game.config.json` example demonstrating `wrapper` and `embedded` modes. 

### Testing
- Attempted an automated build with `dotnet build ChildhoodGame.sln -c Release`, but it failed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No other automated tests (unit/integration) were present or executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd7b3c9a48324bb5b8eb9db14789a)