### PR TITLE
Add deterministic autowin strategy mode with win-condition detectors

### DIFF
--- a/ChildhoodGame.sln
+++ b/ChildhoodGame.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildhoodGame.Core", "src\C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildhoodGame.Runner", "src\ChildhoodGame.Runner\ChildhoodGame.Runner.csproj", "{F24A628D-0C9C-47BE-A36F-C2D2D0F1E7CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildhoodGame.Core.Tests", "tests\ChildhoodGame.Core.Tests\ChildhoodGame.Core.Tests.csproj", "{A1A95E63-B5C9-4D9D-A46B-9114E3D5F3C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{F24A628D-0C9C-47BE-A36F-C2D2D0F1E7CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F24A628D-0C9C-47BE-A36F-C2D2D0F1E7CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F24A628D-0C9C-47BE-A36F-C2D2D0F1E7CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1A95E63-B5C9-4D9D-A46B-9114E3D5F3C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A95E63-B5C9-4D9D-A46B-9114E3D5F3C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A95E63-B5C9-4D9D-A46B-9114E3D5F3C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A95E63-B5C9-4D9D-A46B-9114E3D5F3C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ The launcher opens a desktop window where you can:
 
 You can also drag and drop the target game folder onto the launcher window.
 
+## Auto-win simulation mode
+
+The runner also supports a deterministic automation loop:
+
+```bash
+dotnet run --project src/ChildhoodGame.Runner/ChildhoodGame.Runner.csproj -- --autowin --steps 20 --delay-ms 0
+```
+
+`--autowin` runs a strategy-driven state loop that repeatedly:
+
+- reads game state from runtime
+- selects next action(s)
+- applies input commands
+- evaluates win conditions (score, level, objective flags)
+
+The console output is stable and step-based so it can be used in CI logs.
+
 ## Game folder requirements
 
 The loader validates that the selected folder contains:

--- a/src/ChildhoodGame.Core/Strategy/ActionStrategy.cs
+++ b/src/ChildhoodGame.Core/Strategy/ActionStrategy.cs
@@ -1,0 +1,31 @@
+namespace ChildhoodGame.Core.Strategy;
+
+public interface IActionSelectionStrategy
+{
+    IReadOnlyList<string> SelectActions(GameRuntimeState state);
+}
+
+public sealed class DeterministicAutoWinActionStrategy : IActionSelectionStrategy
+{
+    public const string BossKeyObjective = "boss_key";
+
+    public IReadOnlyList<string> SelectActions(GameRuntimeState state)
+    {
+        if (state.Score < 50)
+        {
+            return new[] { "GAIN_SCORE" };
+        }
+
+        if (state.Level < 3)
+        {
+            return new[] { "ADVANCE_LEVEL" };
+        }
+
+        if (!state.TryGetObjectiveFlag(BossKeyObjective, out var objectiveComplete) || !objectiveComplete)
+        {
+            return new[] { $"COMPLETE_OBJECTIVE:{BossKeyObjective}" };
+        }
+
+        return Array.Empty<string>();
+    }
+}

--- a/src/ChildhoodGame.Core/Strategy/AutoWinLoop.cs
+++ b/src/ChildhoodGame.Core/Strategy/AutoWinLoop.cs
@@ -1,0 +1,74 @@
+namespace ChildhoodGame.Core.Strategy;
+
+public sealed record AutoWinOptions(int MaxSteps, int DelayMilliseconds = 0);
+
+public sealed record AutoWinProgress(
+    int Step,
+    GameRuntimeState StateBeforeActions,
+    IReadOnlyList<string> Actions,
+    GameRuntimeState StateAfterActions,
+    bool IsWin,
+    IReadOnlyList<string> SatisfiedConditions);
+
+public sealed record AutoWinResult(bool IsWin, int StepsExecuted, IReadOnlyList<AutoWinProgress> Progress);
+
+public sealed class AutoWinLoop
+{
+    private readonly IGameStateRuntime runtime;
+    private readonly IActionSelectionStrategy actionStrategy;
+    private readonly IReadOnlyList<IWinConditionDetector> winConditionDetectors;
+
+    public AutoWinLoop(
+        IGameStateRuntime runtime,
+        IActionSelectionStrategy actionStrategy,
+        IEnumerable<IWinConditionDetector> winConditionDetectors)
+    {
+        this.runtime = runtime;
+        this.actionStrategy = actionStrategy;
+        this.winConditionDetectors = winConditionDetectors.ToArray();
+    }
+
+    public async Task<AutoWinResult> RunAsync(AutoWinOptions options, CancellationToken cancellationToken = default)
+    {
+        if (options.MaxSteps <= 0)
+        {
+            return new AutoWinResult(false, 0, Array.Empty<AutoWinProgress>());
+        }
+
+        var progress = new List<AutoWinProgress>();
+
+        for (var step = 1; step <= options.MaxSteps; step++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var stateBefore = await runtime.ReadStateAsync(cancellationToken);
+            var actions = actionStrategy.SelectActions(stateBefore);
+
+            foreach (var action in actions)
+            {
+                await runtime.SendInputAsync(action, cancellationToken);
+            }
+
+            var stateAfter = await runtime.ReadStateAsync(cancellationToken);
+            var satisfied = winConditionDetectors
+                .Where(detector => detector.IsSatisfied(stateAfter))
+                .Select(detector => detector.Name)
+                .ToArray();
+
+            var isWin = satisfied.Length == winConditionDetectors.Count;
+            progress.Add(new AutoWinProgress(step, stateBefore, actions, stateAfter, isWin, satisfied));
+
+            if (isWin)
+            {
+                return new AutoWinResult(true, step, progress);
+            }
+
+            if (options.DelayMilliseconds > 0)
+            {
+                await Task.Delay(options.DelayMilliseconds, cancellationToken);
+            }
+        }
+
+        return new AutoWinResult(false, options.MaxSteps, progress);
+    }
+}

--- a/src/ChildhoodGame.Core/Strategy/GameStateModels.cs
+++ b/src/ChildhoodGame.Core/Strategy/GameStateModels.cs
@@ -1,0 +1,24 @@
+namespace ChildhoodGame.Core.Strategy;
+
+public sealed record GameRuntimeState(
+    int Score,
+    int Level,
+    IReadOnlyDictionary<string, bool> ObjectiveFlags)
+{
+    public bool TryGetObjectiveFlag(string flagName, out bool isCompleted)
+    {
+        if (ObjectiveFlags.TryGetValue(flagName, out var value))
+        {
+            isCompleted = value;
+            return true;
+        }
+
+        isCompleted = false;
+        return false;
+    }
+}
+
+public interface IGameStateRuntime : IGameRuntime
+{
+    Task<GameRuntimeState> ReadStateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/ChildhoodGame.Core/Strategy/IWinConditionDetector.cs
+++ b/src/ChildhoodGame.Core/Strategy/IWinConditionDetector.cs
@@ -1,0 +1,8 @@
+namespace ChildhoodGame.Core.Strategy;
+
+public interface IWinConditionDetector
+{
+    string Name { get; }
+
+    bool IsSatisfied(GameRuntimeState state);
+}

--- a/src/ChildhoodGame.Core/Strategy/MockedGameStateRuntime.cs
+++ b/src/ChildhoodGame.Core/Strategy/MockedGameStateRuntime.cs
@@ -1,0 +1,74 @@
+namespace ChildhoodGame.Core.Strategy;
+
+public sealed class MockedGameStateRuntime : IGameStateRuntime
+{
+    private GameRuntimeState state;
+
+    public MockedGameStateRuntime(GameRuntimeState initialState)
+    {
+        state = initialState;
+    }
+
+    public bool IsRunning { get; private set; }
+
+    public Task StartAsync(GamePackage gamePackage, CancellationToken cancellationToken = default)
+    {
+        IsRunning = true;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        IsRunning = false;
+        return Task.CompletedTask;
+    }
+
+    public Task SendInputAsync(string inputCommand, CancellationToken cancellationToken = default)
+    {
+        if (!IsRunning)
+        {
+            throw new InvalidOperationException("Runtime has not been started.");
+        }
+
+        var objectiveFlags = new Dictionary<string, bool>(state.ObjectiveFlags, StringComparer.OrdinalIgnoreCase);
+
+        if (inputCommand.Equals("GAIN_SCORE", StringComparison.OrdinalIgnoreCase))
+        {
+            state = state with { Score = state.Score + 10 };
+            return Task.CompletedTask;
+        }
+
+        if (inputCommand.Equals("ADVANCE_LEVEL", StringComparison.OrdinalIgnoreCase))
+        {
+            state = state with { Level = state.Level + 1 };
+            return Task.CompletedTask;
+        }
+
+        if (inputCommand.StartsWith("COMPLETE_OBJECTIVE:", StringComparison.OrdinalIgnoreCase))
+        {
+            var objective = inputCommand["COMPLETE_OBJECTIVE:".Length..];
+            objectiveFlags[objective] = true;
+            state = state with { ObjectiveFlags = objectiveFlags };
+            return Task.CompletedTask;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<GameRuntimeState> ReadStateAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsRunning)
+        {
+            throw new InvalidOperationException("Runtime has not been started.");
+        }
+
+        var snapshot = state with { ObjectiveFlags = new Dictionary<string, bool>(state.ObjectiveFlags, StringComparer.OrdinalIgnoreCase) };
+        return Task.FromResult(snapshot);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        IsRunning = false;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/ChildhoodGame.Core/Strategy/WinConditionDetectors.cs
+++ b/src/ChildhoodGame.Core/Strategy/WinConditionDetectors.cs
@@ -1,0 +1,44 @@
+namespace ChildhoodGame.Core.Strategy;
+
+public sealed class ScoreWinConditionDetector : IWinConditionDetector
+{
+    private readonly int requiredScore;
+
+    public ScoreWinConditionDetector(int requiredScore)
+    {
+        this.requiredScore = requiredScore;
+    }
+
+    public string Name => $"Score >= {requiredScore}";
+
+    public bool IsSatisfied(GameRuntimeState state) => state.Score >= requiredScore;
+}
+
+public sealed class LevelWinConditionDetector : IWinConditionDetector
+{
+    private readonly int requiredLevel;
+
+    public LevelWinConditionDetector(int requiredLevel)
+    {
+        this.requiredLevel = requiredLevel;
+    }
+
+    public string Name => $"Level >= {requiredLevel}";
+
+    public bool IsSatisfied(GameRuntimeState state) => state.Level >= requiredLevel;
+}
+
+public sealed class ObjectiveFlagWinConditionDetector : IWinConditionDetector
+{
+    private readonly string objectiveFlagName;
+
+    public ObjectiveFlagWinConditionDetector(string objectiveFlagName)
+    {
+        this.objectiveFlagName = objectiveFlagName;
+    }
+
+    public string Name => $"Objective '{objectiveFlagName}' complete";
+
+    public bool IsSatisfied(GameRuntimeState state) =>
+        state.TryGetObjectiveFlag(objectiveFlagName, out var isCompleted) && isCompleted;
+}

--- a/src/ChildhoodGame.Runner/ChildhoodGame.Runner.csproj
+++ b/src/ChildhoodGame.Runner/ChildhoodGame.Runner.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/ChildhoodGame.Runner/Program.cs
+++ b/src/ChildhoodGame.Runner/Program.cs
@@ -1,11 +1,85 @@
+using ChildhoodGame.Core;
+using ChildhoodGame.Core.Strategy;
+
 namespace ChildhoodGame.Runner;
 
 internal static class Program
 {
     [STAThread]
-    private static void Main()
+    private static void Main(string[] args)
     {
+        if (args.Any(arg => arg.Equals("--autowin", StringComparison.OrdinalIgnoreCase)))
+        {
+            RunAutoWinModeAsync(args).GetAwaiter().GetResult();
+            return;
+        }
+
         ApplicationConfiguration.Initialize();
         Application.Run(new GameLauncherForm());
+    }
+
+    private static async Task RunAutoWinModeAsync(string[] args)
+    {
+        var maxSteps = ParseOption(args, "--steps", defaultValue: 20);
+        var delayMs = ParseOption(args, "--delay-ms", defaultValue: 0);
+
+        await using var runtime = new MockedGameStateRuntime(
+            new GameRuntimeState(
+                Score: 0,
+                Level: 1,
+                ObjectiveFlags: new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)));
+
+        var package = new GamePackage(
+            GameRootPath: Environment.CurrentDirectory,
+            GameExecutablePath: "MOCK.EXE",
+            DosConfigPath: "DOSBOX.CONF",
+            RuntimeConfig: new DosRuntimeConfig("embedded", null, null, null),
+            SaveStatePath: null,
+            LoadStatePath: null);
+
+        await runtime.StartAsync(package);
+
+        var detectors = new IWinConditionDetector[]
+        {
+            new ScoreWinConditionDetector(50),
+            new LevelWinConditionDetector(3),
+            new ObjectiveFlagWinConditionDetector(DeterministicAutoWinActionStrategy.BossKeyObjective)
+        };
+
+        var loop = new AutoWinLoop(runtime, new DeterministicAutoWinActionStrategy(), detectors);
+        var result = await loop.RunAsync(new AutoWinOptions(maxSteps, delayMs));
+
+        Console.WriteLine("AUTOWIN MODE START");
+        foreach (var entry in result.Progress)
+        {
+            var actionsText = entry.Actions.Count == 0 ? "<none>" : string.Join(',', entry.Actions);
+            var satisfiedText = entry.SatisfiedConditions.Count == 0 ? "<none>" : string.Join('|', entry.SatisfiedConditions);
+            Console.WriteLine(
+                $"STEP={entry.Step};STATE={entry.StateAfterActions.Score}/{entry.StateAfterActions.Level};ACTIONS={actionsText};CONDITIONS={satisfiedText};WIN={(entry.IsWin ? "yes" : "no")}");
+        }
+
+        Console.WriteLine(result.IsWin
+            ? $"AUTOWIN RESULT: WIN in {result.StepsExecuted} step(s)."
+            : $"AUTOWIN RESULT: INCOMPLETE after {result.StepsExecuted} step(s).");
+
+        await runtime.StopAsync();
+    }
+
+    private static int ParseOption(string[] args, string optionName, int defaultValue)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (!args[i].Equals(optionName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (int.TryParse(args[i + 1], out var parsed) && parsed > 0)
+            {
+                return parsed;
+            }
+        }
+
+        return defaultValue;
     }
 }

--- a/tests/ChildhoodGame.Core.Tests/AutoWinLoopTests.cs
+++ b/tests/ChildhoodGame.Core.Tests/AutoWinLoopTests.cs
@@ -1,0 +1,54 @@
+using ChildhoodGame.Core;
+using ChildhoodGame.Core.Strategy;
+
+namespace ChildhoodGame.Core.Tests;
+
+public sealed class AutoWinLoopTests
+{
+    [Fact]
+    public async Task MockedRuntime_TransitionsState_FromAppliedInputs()
+    {
+        await using var runtime = new MockedGameStateRuntime(new GameRuntimeState(0, 1, new Dictionary<string, bool>()));
+        await runtime.StartAsync(BuildPackage());
+
+        await runtime.SendInputAsync("GAIN_SCORE");
+        await runtime.SendInputAsync("ADVANCE_LEVEL");
+        await runtime.SendInputAsync("COMPLETE_OBJECTIVE:boss_key");
+
+        var state = await runtime.ReadStateAsync();
+
+        Assert.Equal(10, state.Score);
+        Assert.Equal(2, state.Level);
+        Assert.True(state.TryGetObjectiveFlag("boss_key", out var completed) && completed);
+    }
+
+    [Fact]
+    public async Task AutoWinLoop_ReachesWin_WhenAllDetectorsSatisfied()
+    {
+        await using var runtime = new MockedGameStateRuntime(new GameRuntimeState(0, 1, new Dictionary<string, bool>()));
+        await runtime.StartAsync(BuildPackage());
+
+        var detectors = new IWinConditionDetector[]
+        {
+            new ScoreWinConditionDetector(50),
+            new LevelWinConditionDetector(3),
+            new ObjectiveFlagWinConditionDetector(DeterministicAutoWinActionStrategy.BossKeyObjective)
+        };
+
+        var loop = new AutoWinLoop(runtime, new DeterministicAutoWinActionStrategy(), detectors);
+        var result = await loop.RunAsync(new AutoWinOptions(MaxSteps: 20));
+
+        Assert.True(result.IsWin);
+        Assert.Equal(8, result.StepsExecuted);
+        Assert.True(result.Progress.Last().IsWin);
+    }
+
+    private static GamePackage BuildPackage() =>
+        new(
+            GameRootPath: "/tmp",
+            GameExecutablePath: "MOCK.EXE",
+            DosConfigPath: "DOSBOX.CONF",
+            RuntimeConfig: new DosRuntimeConfig("embedded", null, null, null),
+            SaveStatePath: null,
+            LoadStatePath: null);
+}

--- a/tests/ChildhoodGame.Core.Tests/ChildhoodGame.Core.Tests.csproj
+++ b/tests/ChildhoodGame.Core.Tests/ChildhoodGame.Core.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ChildhoodGame.Core\ChildhoodGame.Core.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Motivation
- Provide a deterministic automation mode that can evaluate observable runtime state and drive inputs toward a win condition for CI-friendly simulation and debugging.
- Allow win conditions to be expressed over simple, testable runtime observations like score, level, and objective flags.
- Enable a testable loop that reads state, chooses actions, applies inputs, and reports deterministic step-wise progress.

### Description
- Added a `ChildhoodGame.Core.Strategy` module with `GameRuntimeState` and `IGameStateRuntime` to represent and read observable runtime state (`Score`, `Level`, `ObjectiveFlags`).
- Introduced `IWinConditionDetector` and concrete detectors `ScoreWinConditionDetector`, `LevelWinConditionDetector`, and `ObjectiveFlagWinConditionDetector` to evaluate win conditions against `GameRuntimeState`.
- Implemented `IActionSelectionStrategy` and a deterministic `DeterministicAutoWinActionStrategy` that selects `GAIN_SCORE`, `ADVANCE_LEVEL`, and `COMPLETE_OBJECTIVE:boss_key` actions.
- Implemented `AutoWinLoop` that performs the cycle: read state → select actions → send inputs → re-read state → evaluate detectors, and returns detailed per-step `AutoWinProgress` and overall `AutoWinResult`.
- Added `MockedGameStateRuntime` to simulate state transitions for deterministic behavior and tests, exposed `--autowin` mode in the runner (`Program.cs`) with `--steps`/`--delay-ms` options and stable console progress output, and changed runner `OutputType` to `Exe` to allow console output.
- Added `tests/ChildhoodGame.Core.Tests` with `AutoWinLoopTests` that assert mocked runtime transitions and that the loop reaches a win (expected `StepsExecuted == 8`) given the detectors and strategy.
- Updated `ChildhoodGame.sln` and `README.md` to include the new test project and document the auto-win simulation mode.

### Testing
- Added automated tests under `tests/ChildhoodGame.Core.Tests/AutoWinLoopTests.cs` that validate the mocked runtime state transitions and that `AutoWinLoop` reaches the expected win scenario (asserting `IsWin` and `StepsExecuted == 8`).
- The test project `tests/ChildhoodGame.Core.Tests/ChildhoodGame.Core.Tests.csproj` was added and referenced from the solution. 
- Tests were not executed in this environment because the `dotnet` CLI is not available here, so automated test runs could not be performed (tests should pass when run with a proper .NET SDK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf0aeb41883248b78d4f66e3212a0)